### PR TITLE
Catch exceptions at this point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,12 @@ import promisify = require('util.promisify')
 const readPackageJson = promisify(readPackageJsonCB)
 
 export default function readPkg (pkgPath: string): Promise<PackageJson> {
-  return readPackageJson(pkgPath)
+  try {
+    return readPackageJson(pkgPath);
+  } catch (err) {
+    console.error(`Error in parsing package.json: ${err.message)`);
+    return Promise.resolve({});
+  }
 }
 
 export function fromDir (pkgPath: string): Promise<PackageJson> {


### PR DESCRIPTION
If an exception is thrown from here then the exception will likely propagate all the way up to the top of pnpm, yielding a scary-looking stack trace that looks like pnpm crashed. Ideally if the user makes an error in their package.json (such as a space instead of a hyphen in the package name), the user should get an error message that points them towards their error and away from complaining about pnpm.